### PR TITLE
[update] fix server panic due to use of closed db

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ func SetupRouter(db_name string) (*gin.Engine, *sql.DB) {
     if err != nil {
         log.Fatal(err)
     }
-    defer db.Close()
 
     // Providing this database instance to all the requests into there context it self
     // which they can access using `c.db` where `c` is *gin.Context
@@ -40,7 +39,8 @@ func SetupRouter(db_name string) (*gin.Engine, *sql.DB) {
 
 func main() {
     godotenv.Load(".env")
-    router, _ := SetupRouter("jukebox")
+    router, db := SetupRouter("jukebox")
+    defer db.Close()
 
     var port string = os.Getenv("PORT")
     if len(port)==0 {


### PR DESCRIPTION
## Description
The server was giving errors just after the start

## Cause
db instance was used, after being closed due to `defer` statement in `SetupRouter` function

## Solution
Moved the defer statement for `db.Close()` to main function